### PR TITLE
Remove ripgrep plugin

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -70,7 +70,7 @@ ZSH_THEME="robbyrussell"
 # Custom plugins may be added to $ZSH_CUSTOM/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
-plugins=(git ripgrep vscode)
+plugins=(git vscode)
 
 source $ZSH/oh-my-zsh.sh
 


### PR DESCRIPTION
Removes ripgrep oh-my-zsh plugin. Completion is included by default when installed via package manager, making the plugin obsolete.